### PR TITLE
Add: Implementando el archivo DAO para tener una capa extra de seguridad

### DIFF
--- a/src/dao/sensor.dao.js
+++ b/src/dao/sensor.dao.js
@@ -1,0 +1,8 @@
+import sensorModel from "../models/sensor.model";
+const sensorDao = {}
+
+sensorDao.addSensor = async (sensor) => {
+    return await sensorModel.create(sensor);
+}
+
+export default sensorDao;


### PR DESCRIPTION
Se implementó el archivo de DAO para tener una capa intermedia y evitar una conexión directa con la base de datos.




